### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/chef-api.rb
+++ b/lib/chef-api.rb
@@ -1,7 +1,7 @@
 require "json"
 require "logify"
 require "pathname"
-require "chef-api/version"
+require_relative "chef-api/version"
 
 module ChefAPI
   autoload :Authentication,  "chef-api/authentication"

--- a/lib/chef-api/defaults.rb
+++ b/lib/chef-api/defaults.rb
@@ -1,4 +1,4 @@
-require "chef-api/version"
+require_relative "version"
 require "pathname"
 require "json"
 

--- a/lib/chef-api/resource.rb
+++ b/lib/chef-api/resource.rb
@@ -1,4 +1,4 @@
-require "chef-api/aclable"
+require_relative "aclable"
 module ChefAPI
   module Resource
     autoload :Base,            "chef-api/resources/base"


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>