### PR TITLE
Switch logging to mixlib-log instead of logify

### DIFF
--- a/chef-api.gemspec
+++ b/chef-api.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "logify", "~> 0.1"
+  spec.add_dependency "mixlib-log", "~> 3.0"
   spec.add_dependency "mime-types"
 end

--- a/chef-infra-api.gemspec
+++ b/chef-infra-api.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "logify", "~> 0.1"
+  spec.add_dependency "mixlib-log", "~> 3.0"
   spec.add_dependency "mime-types"
 end

--- a/lib/chef-api.rb
+++ b/lib/chef-api.rb
@@ -1,6 +1,6 @@
 require "json"
-require "logify"
 require "pathname"
+require_relative "chef-api/log"
 require_relative "chef-api/version"
 
 module ChefAPI
@@ -35,7 +35,7 @@ module ChefAPI
     #   the log level to set
     #
     def log_level=(level)
-      Logify.level = level
+      ChefAPI::Log.level = level
     end
 
     #
@@ -44,7 +44,7 @@ module ChefAPI
     # @return [Symbol]
     #
     def log_level
-      Logify.level
+      ChefAPI::Log.level
     end
 
     #

--- a/lib/chef-api/authentication.rb
+++ b/lib/chef-api/authentication.rb
@@ -11,7 +11,6 @@ require "time"
 
 module ChefAPI
   class Authentication
-    include Logify
 
     # @todo: Enable this in the future when Mixlib::Authentication supports
     # signing the full request body instead of just the uploaded file parameter.
@@ -148,22 +147,22 @@ module ChefAPI
     def canonical_key
       return @canonical_key if @canonical_key
 
-      log.info "Parsing private key..."
+      ChefAPI::Log.info "Parsing private key..."
 
       if @key.nil?
-        log.warn "No private key given!"
+        ChefAPI::Log.warn "No private key given!"
         raise "No private key given!"
       end
 
       if @key.is_a?(OpenSSL::PKey::RSA)
-        log.debug "Detected private key is an OpenSSL Ruby object"
+        ChefAPI::Log.debug "Detected private key is an OpenSSL Ruby object"
         @canonical_key = @key
       elsif @key =~ /(.+)\.pem$/ || File.exist?(File.expand_path(@key))
-        log.debug "Detected private key is the path to a file"
+        ChefAPI::Log.debug "Detected private key is the path to a file"
         contents = File.read(File.expand_path(@key))
         @canonical_key = OpenSSL::PKey::RSA.new(contents)
       else
-        log.debug "Detected private key was the literal string key"
+        ChefAPI::Log.debug "Detected private key was the literal string key"
         @canonical_key = OpenSSL::PKey::RSA.new(@key)
       end
 

--- a/lib/chef-api/log.rb
+++ b/lib/chef-api/log.rb
@@ -1,0 +1,7 @@
+require "mixlib/log"
+
+module ChefAPI
+  class Log
+    extend Mixlib::Log
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ RSpec.configure do |config|
 
   #
   config.before(:each) do
-    Logify.level = :fatal
+    ChefAPI::Log.level = :fatal
   end
 
   # Run specs in random order to surface order dependencies. If you find an


### PR DESCRIPTION
## Description
Switched from the pulled logify Gem for logging to mixlib-log.

I did not touch the tests, though as they were failing in the first place. Functionality is backwards-compatible and just references the Mixlib library without own logic. Copy and paste from InSpec's logging basically.

## Related Issue
Solves #74 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have updated the documentation accordingly.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
