### PR TITLE
Loosen the mixlib-log dep to allow for older ruby releases

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,1 +1,0 @@
-daysUntilLock: 60

--- a/chef-api.gemspec
+++ b/chef-api.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mixlib-log", "~> 3.0"
+  spec.add_dependency "mixlib-log", ">= 1", "< 4" # we need to validate 4.x before we loosen this
   spec.add_dependency "mime-types"
 end

--- a/chef-infra-api.gemspec
+++ b/chef-infra-api.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mixlib-log", "~> 3.0"
+  spec.add_dependency "mixlib-log", ">= 1", "< 4" # we need to validate 4.x before we loosen this
   spec.add_dependency "mime-types"
 end


### PR DESCRIPTION
3.x requires modern ruby

Signed-off-by: Tim Smith <tsmith@chef.io>