### PR TITLE
Avoid Ruby 2.7 deprecation warnings by switching to CGI

### DIFF
--- a/lib/chef-api/connection.rb
+++ b/lib/chef-api/connection.rb
@@ -2,6 +2,7 @@ require "net/http"
 require "net/https"
 require "openssl"
 require "uri"
+require "cgi"
 
 module ChefAPI
   #
@@ -376,7 +377,7 @@ module ChefAPI
     #
     def to_query_string(hash)
       hash.map do |key, value|
-        "#{URI.escape(key.to_s)}=#{URI.escape(value.to_s)}"
+        "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"
       end.join("&")[/.+/]
     end
 

--- a/lib/chef-api/resources/base.rb
+++ b/lib/chef-api/resources/base.rb
@@ -1,6 +1,8 @@
 module ChefAPI
   class Resource::Base
     class << self
+      require "cgi"
+
       # Including the Enumberable module gives us magic
       include Enumerable
 
@@ -512,7 +514,7 @@ module ChefAPI
             raise Error::MissingURLParameter.new(param: key)
           end
 
-          URI.escape(value)
+          CGI.escape(value)
         end.sub(%r{^/}, "") # Remove leading slash
       end
 

--- a/lib/chef-api/resources/user.rb
+++ b/lib/chef-api/resources/user.rb
@@ -1,5 +1,7 @@
 module ChefAPI
   class Resource::User < Resource::Base
+    require "cgi"
+
     collection_path "/users"
 
     schema do
@@ -38,7 +40,7 @@ module ChefAPI
         # HEC/EC returns a slightly different response than OSC/CZ
         if users.is_a?(Array)
           users.each do |info|
-            name = URI.escape(info["user"]["username"])
+            name = CGI.escape(info["user"]["username"])
             response = connection.get("/users/#{name}")
             result = from_json(response, prefix)
 


### PR DESCRIPTION
Move from URI to CGI to avoid deprecation warnings.

Signed-off-by: Tim Smith <tsmith@chef.io>