### PR TITLE
Optimize our requires

### DIFF
--- a/lib/chef-api.rb
+++ b/lib/chef-api.rb
@@ -1,5 +1,5 @@
-require "json"
-require "pathname"
+require "json" unless defined?(JSON)
+require "pathname" unless defined?(Pathname)
 require_relative "chef-api/log"
 require_relative "chef-api/version"
 

--- a/lib/chef-api/authentication.rb
+++ b/lib/chef-api/authentication.rb
@@ -1,7 +1,7 @@
-require "base64"
-require "digest"
-require "openssl"
-require "time"
+require "base64" unless defined?(Base64)
+require "digest" unless defined?(Digest)
+require "openssl" unless defined?(OpenSSL)
+require "time" unless defined?(Time)
 
 #
 # DEBUG steps:

--- a/lib/chef-api/connection.rb
+++ b/lib/chef-api/connection.rb
@@ -1,8 +1,7 @@
-require "net/http"
-require "net/https"
-require "openssl"
-require "uri"
-require "cgi"
+require "net/http" unless defined?(Net::HTTP)
+require "openssl" unless defined?(OpenSSL)
+require "uri" unless defined?(URI)
+require "cgi" unless defined?(CGI)
 
 module ChefAPI
   #

--- a/lib/chef-api/defaults.rb
+++ b/lib/chef-api/defaults.rb
@@ -1,6 +1,6 @@
 require_relative "version"
-require "pathname"
-require "json"
+require "pathname" unless defined?(Pathname)
+require "json" unless defined?(JSON)
 
 module ChefAPI
   module Defaults

--- a/lib/chef-api/errors.rb
+++ b/lib/chef-api/errors.rb
@@ -1,4 +1,4 @@
-require "erb"
+require "erb" unless defined?(Erb)
 
 module ChefAPI
   module Error

--- a/lib/chef-api/multipart.rb
+++ b/lib/chef-api/multipart.rb
@@ -1,5 +1,5 @@
-require "cgi"
-require "mime/types"
+require "cgi" unless defined?(CGI)
+require "mime/types" unless defined?(MIME::Types)
 
 module ChefAPI
   module Multipart

--- a/lib/chef-api/resources/base.rb
+++ b/lib/chef-api/resources/base.rb
@@ -1,7 +1,7 @@
 module ChefAPI
   class Resource::Base
     class << self
-      require "cgi"
+      require "cgi" unless defined?(CGI)
 
       # Including the Enumberable module gives us magic
       include Enumerable

--- a/lib/chef-api/resources/user.rb
+++ b/lib/chef-api/resources/user.rb
@@ -1,6 +1,6 @@
 module ChefAPI
   class Resource::User < Resource::Base
-    require "cgi"
+    require "cgi" unless defined?(CGI)
 
     collection_path "/users"
 

--- a/spec/support/chef_server.rb
+++ b/spec/support/chef_server.rb
@@ -97,7 +97,7 @@ module RSpec
     entity :role,        :roles
     entity :user,        :users
 
-    require "singleton"
+    require "singleton" unless defined?(Singleton)
     include Singleton
 
     #


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>